### PR TITLE
fix(rabbit): rebind subscriptions after reconnect

### DIFF
--- a/loudhailer/backends/rabbitmq.py
+++ b/loudhailer/backends/rabbitmq.py
@@ -39,6 +39,8 @@ class RMQBackend(BackendBase):
         self._consumer_task = None
         self._consumer_event = asyncio.Event()
         self._ready_event = asyncio.Event()
+        self._subscribed_channels = set()
+        self._sub_lock = asyncio.Lock()
 
     async def on_message(self, message):
         await self._listen_queue.put(
@@ -65,16 +67,29 @@ class RMQBackend(BackendBase):
             await self._connection.close()
 
     async def subscribe(self, channel):
-        await self._consumer_channel.queue_bind(self._queue_name, self._exchange_name, channel)
-        logger.debug(
-            f'Bind channel {channel} to exchange {self._exchange_name} queue {self._queue_name}',
-        )
+        # Contract: if queue_bind raises, the channel is NOT added to the
+        # tracking set and will not be rebound on reconnect. Callers that
+        # need at-least-one-success semantics must retry themselves.
+        async with self._sub_lock:
+            await self._consumer_channel.queue_bind(
+                self._queue_name, self._exchange_name, channel,
+            )
+            self._subscribed_channels.add(channel)
+            logger.debug(
+                f'Bind channel {channel} to exchange {self._exchange_name} '
+                f'queue {self._queue_name}',
+            )
 
     async def unsubscribe(self, channel):
-        await self._consumer_channel.queue_unbind(self._queue_name, self._exchange_name, channel)
-        logger.debug(
-            f'Unbind channel {channel} to exchange {self._exchange_name} queue {self._queue_name}',
-        )
+        async with self._sub_lock:
+            await self._consumer_channel.queue_unbind(
+                self._queue_name, self._exchange_name, channel,
+            )
+            self._subscribed_channels.discard(channel)
+            logger.debug(
+                f'Unbind channel {channel} to exchange {self._exchange_name} '
+                f'queue {self._queue_name}',
+            )
 
     async def publish(self, envelope):
         for _ in range(self._publish_retries):
@@ -102,10 +117,30 @@ class RMQBackend(BackendBase):
                 await asyncio.wait_for(self._connect(), timeout=self._connect_timeout)
 
     async def _ensure_consumer_channel(self):
-        if not self._consumer_channel or self._consumer_channel.is_closed:
+        # Hold _sub_lock across channel creation AND rebind: prevents a
+        # concurrent subscribe/unsubscribe from mutating
+        # _subscribed_channels during our iteration (RuntimeError: Set
+        # changed size during iteration) and from binding on a channel
+        # that is still mid-setup.
+        async with self._sub_lock:
+            if self._consumer_channel and not self._consumer_channel.is_closed:
+                return
             self._consumer_channel = await self._connection.channel()
             await self._consumer_channel.exchange_declare(self._exchange_name)
             await self._consumer_channel.queue_declare(self._queue_name, exclusive=True)
+            if self._subscribed_channels:
+                logger.info(
+                    f'Rebinding {len(self._subscribed_channels)} channel(s) '
+                    f'to queue {self._queue_name} after (re)connect',
+                )
+            for channel in self._subscribed_channels:
+                await self._consumer_channel.queue_bind(
+                    self._queue_name, self._exchange_name, channel,
+                )
+                logger.debug(
+                    f'Rebound channel {channel} to exchange '
+                    f'{self._exchange_name} queue {self._queue_name}',
+                )
 
     async def _ensure_producer_channel(self):
         if not self._producer_channel or self._producer_channel.is_closed:

--- a/tests/e2e/test_loudhailer.py
+++ b/tests/e2e/test_loudhailer.py
@@ -32,6 +32,39 @@ async def test_loudhailer_rabbitmq(fastapi_port):
 
 
 @pytest.mark.asyncio
+async def test_loudhailer_rabbitmq_rebinds_after_connection_drop():
+    """Regression for LITE-34115: when the AMQP connection drops, the
+    backend must rebind previously-subscribed channels to the freshly
+    declared exclusive queue so messages keep flowing.
+    """
+    async with Loudhailer(RABBITMQ_URL) as producer:
+        async with Loudhailer(RABBITMQ_URL) as consumer:
+            async with consumer.subscribe('lite_34115') as messages:
+                await asyncio.sleep(0.1)
+                await producer.publish(RecipientType.GROUP, 'lite_34115', {'n': 1})
+                assert await asyncio.wait_for(messages.get(), timeout=2) == {'n': 1}
+
+                old_channel = consumer._backend._consumer_channel
+                await consumer._backend._connection.close()
+
+                # Deterministic wait: the reconnect loop replaces
+                # _consumer_channel with a fresh object and then sets
+                # _ready_event. Polling on both guards against either the
+                # stale pre-disconnect set() or a partially-reset state.
+                deadline = asyncio.get_running_loop().time() + 5
+                while (
+                    consumer._backend._consumer_channel is old_channel
+                    or not consumer._backend._ready_event.is_set()
+                ):
+                    if asyncio.get_running_loop().time() >= deadline:
+                        raise AssertionError('reconnect did not complete in time')
+                    await asyncio.sleep(0.05)
+
+                await producer.publish(RecipientType.GROUP, 'lite_34115', {'n': 2})
+                assert await asyncio.wait_for(messages.get(), timeout=5) == {'n': 2}
+
+
+@pytest.mark.asyncio
 async def test_loudhailer_redis(fastapi_port):
     async with Loudhailer(REDIS_URL) as loudhailer:
         url = f'ws://127.0.0.1:{fastapi_port}/ws2'

--- a/tests/loudhailer/backends/test_rabbitmq.py
+++ b/tests/loudhailer/backends/test_rabbitmq.py
@@ -100,6 +100,7 @@ async def test_subscribe(mocker):
     backend._consumer_channel.queue_bind.assert_awaited_once_with(
         backend._queue_name, backend._exchange_name, 'my_group',
     )
+    assert 'my_group' in backend._subscribed_channels
 
 
 @pytest.mark.asyncio
@@ -108,10 +109,31 @@ async def test_unsubscribe(mocker):
         'test://',
     )
     backend._consumer_channel = mocker.MagicMock(queue_unbind=mocker.AsyncMock())
-
+    backend._subscribed_channels.add('my_group')
+    
     await backend.unsubscribe('my_group')
     backend._consumer_channel.queue_unbind.assert_awaited_once_with(
         backend._queue_name, backend._exchange_name, 'my_group',
+    )
+    assert 'my_group' not in backend._subscribed_channels
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_unknown_channel_is_noop_on_set(mocker):
+    """Regression for LITE-34115: discarding a channel that was never
+    subscribed must not crash, must leave the tracking set empty, and
+    must still forward the queue_unbind call to the broker — guarding
+    against a future optimization that skips the AMQP call when the
+    channel is unknown locally.
+    """
+    backend = RMQBackend('test://')
+    backend._consumer_channel = mocker.MagicMock(queue_unbind=mocker.AsyncMock())
+
+    await backend.unsubscribe('never_subscribed')
+
+    assert backend._subscribed_channels == set()
+    backend._consumer_channel.queue_unbind.assert_awaited_once_with(
+        backend._queue_name, backend._exchange_name, 'never_subscribed',
     )
 
 
@@ -219,6 +241,79 @@ async def test_ensure_consumer_channel(mocker):
     await backend._ensure_consumer_channel()
     mocked_channel.exchange_declare.assert_awaited_once_with(backend._exchange_name)
     mocked_channel.queue_declare.assert_awaited_once_with(backend._queue_name, exclusive=True)
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_rebinds_tracked_channels(mocker):
+    """Regression for LITE-34115: on a fresh consumer channel, every
+    tracked channel must be re-bound to the new exclusive queue.
+    """
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+    backend._subscribed_channels = {'group_a', 'group_b'}
+
+    await backend._ensure_consumer_channel()
+
+    assert mocked_channel.queue_bind.await_count == 2
+    bound = {call.args[2] for call in mocked_channel.queue_bind.await_args_list}
+    assert bound == {'group_a', 'group_b'}
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_no_rebind_when_empty(mocker):
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+
+    await backend._ensure_consumer_channel()
+
+    mocked_channel.queue_bind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_rebind_lock_blocks_concurrent_subscribe(mocker):
+    """Regression for LITE-34115 review feedback: the rebind loop holds
+    ``_sub_lock`` so a concurrent ``subscribe()`` blocks until rebind
+    finishes — no ``RuntimeError: Set changed size during iteration``,
+    no ghost bindings.
+    """
+    first_bind_started = asyncio.Event()
+    release_first_bind = asyncio.Event()
+
+    async def slow_queue_bind(*args, **kwargs):
+        first_bind_started.set()
+        await release_first_bind.wait()
+
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(side_effect=slow_queue_bind),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+    backend._subscribed_channels = {'existing'}
+
+    rebind_task = asyncio.create_task(backend._ensure_consumer_channel())
+    await asyncio.wait_for(first_bind_started.wait(), timeout=1)
+
+    subscribe_task = asyncio.create_task(backend.subscribe('new'))
+    await asyncio.sleep(0.05)
+    assert not subscribe_task.done(), 'subscribe must block while rebind holds the lock'
+
+    release_first_bind.set()
+    await asyncio.wait_for(rebind_task, timeout=1)
+    await asyncio.wait_for(subscribe_task, timeout=1)
+
+    assert backend._subscribed_channels == {'existing', 'new'}
 
 
 @pytest.mark.asyncio
@@ -342,6 +437,59 @@ async def test_consumer_generic_exception(mocker, caplog):
     mocked_conn.assert_awaited()
 
     assert 'Something wrong happened' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_consumer_rebinds_subscriptions_after_reconnect(mocker):
+    """Regression for LITE-34115: after the consumer channel closes and a
+    new one is opened, every previously-subscribed channel is rebound to
+    the new queue.
+    """
+    mocker.patch.object(RMQBackend, '_ensure_connection', new=mocker.AsyncMock())
+
+    first_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+        basic_consume=mocker.AsyncMock(),
+        closing=asyncio.Future(),
+        is_closed=False,
+    )
+    second_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+        basic_consume=mocker.AsyncMock(),
+        closing=asyncio.Future(),
+        is_closed=False,
+    )
+
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(
+        channel=mocker.AsyncMock(side_effect=[first_channel, second_channel]),
+    )
+    backend._consumer_event.set()
+    backend._subscribed_channels = {'group_a'}
+
+    task = asyncio.create_task(backend._consumer())
+    await asyncio.sleep(0.05)
+
+    first_channel.is_closed = True
+    first_channel.closing.set_result(None)
+
+    deadline = asyncio.get_running_loop().time() + 2
+    while second_channel.queue_bind.await_count == 0:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError('second channel was not set up in time')
+        await asyncio.sleep(0.01)
+
+    backend._consumer_event.clear()
+    second_channel.closing.set_result(None)
+    await task
+
+    second_channel.queue_bind.assert_awaited_once_with(
+        backend._queue_name, backend._exchange_name, 'group_a',
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/loudhailer/backends/test_rabbitmq.py
+++ b/tests/loudhailer/backends/test_rabbitmq.py
@@ -100,6 +100,7 @@ async def test_subscribe(mocker):
     backend._consumer_channel.queue_bind.assert_awaited_once_with(
         backend._queue_name, backend._exchange_name, 'my_group',
     )
+    assert 'my_group' in backend._subscribed_channels
 
 
 @pytest.mark.asyncio
@@ -108,10 +109,31 @@ async def test_unsubscribe(mocker):
         'test://',
     )
     backend._consumer_channel = mocker.MagicMock(queue_unbind=mocker.AsyncMock())
+    backend._subscribed_channels.add('my_group')
 
     await backend.unsubscribe('my_group')
     backend._consumer_channel.queue_unbind.assert_awaited_once_with(
         backend._queue_name, backend._exchange_name, 'my_group',
+    )
+    assert 'my_group' not in backend._subscribed_channels
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_unknown_channel_is_noop_on_set(mocker):
+    """Regression for LITE-34115: discarding a channel that was never
+    subscribed must not crash, must leave the tracking set empty, and
+    must still forward the queue_unbind call to the broker — guarding
+    against a future optimization that skips the AMQP call when the
+    channel is unknown locally.
+    """
+    backend = RMQBackend('test://')
+    backend._consumer_channel = mocker.MagicMock(queue_unbind=mocker.AsyncMock())
+
+    await backend.unsubscribe('never_subscribed')
+
+    assert backend._subscribed_channels == set()
+    backend._consumer_channel.queue_unbind.assert_awaited_once_with(
+        backend._queue_name, backend._exchange_name, 'never_subscribed',
     )
 
 
@@ -219,6 +241,102 @@ async def test_ensure_consumer_channel(mocker):
     await backend._ensure_consumer_channel()
     mocked_channel.exchange_declare.assert_awaited_once_with(backend._exchange_name)
     mocked_channel.queue_declare.assert_awaited_once_with(backend._queue_name, exclusive=True)
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_reuses_open_channel(mocker):
+    """A second call with the existing channel still open is a no-op: no
+    new channel, no re-declare, no re-bind - just the fast-path return."""
+    mocked_channel = mocker.MagicMock(
+        is_closed=False,
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+    backend._subscribed_channels = {'group_a'}
+
+    await backend._ensure_consumer_channel()
+    await backend._ensure_consumer_channel()
+
+    backend._connection.channel.assert_awaited_once()
+    mocked_channel.exchange_declare.assert_awaited_once()
+    mocked_channel.queue_declare.assert_awaited_once()
+    mocked_channel.queue_bind.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_rebinds_tracked_channels(mocker):
+    """Regression for LITE-34115: on a fresh consumer channel, every
+    tracked channel must be re-bound to the new exclusive queue.
+    """
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+    backend._subscribed_channels = {'group_a', 'group_b'}
+
+    await backend._ensure_consumer_channel()
+
+    assert mocked_channel.queue_bind.await_count == 2
+    bound = {call.args[2] for call in mocked_channel.queue_bind.await_args_list}
+    assert bound == {'group_a', 'group_b'}
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_no_rebind_when_empty(mocker):
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+
+    await backend._ensure_consumer_channel()
+
+    mocked_channel.queue_bind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_consumer_channel_rebind_lock_blocks_concurrent_subscribe(mocker):
+    """Regression for LITE-34115 review feedback: the rebind loop holds
+    ``_sub_lock`` so a concurrent ``subscribe()`` blocks until rebind
+    finishes — no ``RuntimeError: Set changed size during iteration``,
+    no ghost bindings.
+    """
+    first_bind_started = asyncio.Event()
+    release_first_bind = asyncio.Event()
+
+    async def slow_queue_bind(*args, **kwargs):
+        first_bind_started.set()
+        await release_first_bind.wait()
+
+    mocked_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(side_effect=slow_queue_bind),
+    )
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(channel=mocker.AsyncMock(return_value=mocked_channel))
+    backend._subscribed_channels = {'existing'}
+
+    rebind_task = asyncio.create_task(backend._ensure_consumer_channel())
+    await asyncio.wait_for(first_bind_started.wait(), timeout=1)
+
+    subscribe_task = asyncio.create_task(backend.subscribe('new'))
+    await asyncio.sleep(0.05)
+    assert not subscribe_task.done(), 'subscribe must block while rebind holds the lock'
+
+    release_first_bind.set()
+    await asyncio.wait_for(rebind_task, timeout=1)
+    await asyncio.wait_for(subscribe_task, timeout=1)
+
+    assert backend._subscribed_channels == {'existing', 'new'}
 
 
 @pytest.mark.asyncio
@@ -342,6 +460,59 @@ async def test_consumer_generic_exception(mocker, caplog):
     mocked_conn.assert_awaited()
 
     assert 'Something wrong happened' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_consumer_rebinds_subscriptions_after_reconnect(mocker):
+    """Regression for LITE-34115: after the consumer channel closes and a
+    new one is opened, every previously-subscribed channel is rebound to
+    the new queue.
+    """
+    mocker.patch.object(RMQBackend, '_ensure_connection', new=mocker.AsyncMock())
+
+    first_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+        basic_consume=mocker.AsyncMock(),
+        closing=asyncio.Future(),
+        is_closed=False,
+    )
+    second_channel = mocker.MagicMock(
+        exchange_declare=mocker.AsyncMock(),
+        queue_declare=mocker.AsyncMock(),
+        queue_bind=mocker.AsyncMock(),
+        basic_consume=mocker.AsyncMock(),
+        closing=asyncio.Future(),
+        is_closed=False,
+    )
+
+    backend = RMQBackend('test://')
+    backend._connection = mocker.MagicMock(
+        channel=mocker.AsyncMock(side_effect=[first_channel, second_channel]),
+    )
+    backend._consumer_event.set()
+    backend._subscribed_channels = {'group_a'}
+
+    task = asyncio.create_task(backend._consumer())
+    await asyncio.sleep(0.05)
+
+    first_channel.is_closed = True
+    first_channel.closing.set_result(None)
+
+    deadline = asyncio.get_running_loop().time() + 2
+    while second_channel.queue_bind.await_count == 0:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError('second channel was not set up in time')
+        await asyncio.sleep(0.01)
+
+    backend._consumer_event.clear()
+    second_channel.closing.set_result(None)
+    await task
+
+    second_channel.queue_bind.assert_awaited_once_with(
+        backend._queue_name, backend._exchange_name, 'group_a',
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Track subscribed channels in RMQBackend and re-apply queue_bind on every fresh consumer channel so messages keep flowing after a disconnect. 

A new _sub_lock serializes subscribe/unsubscribe with the rebind loop to prevent concurrent set mutation and duplicate binds on a mid-setup channel.

This change is needed because when Rabbit services restart the reconnect does not re-bind since the subscription groups are still there, it silently passes.